### PR TITLE
Multiple file uploads

### DIFF
--- a/class/Upload/Upload.php
+++ b/class/Upload/Upload.php
@@ -7,6 +7,11 @@ use Trackshift\Usage\Aggregation;
 use Trackshift\Usage\UsageList;
 
 abstract class Upload {
+	public readonly string $filename;
+	public readonly int $size;
+	public readonly string $sizeString;
+	public readonly string $type;
+
 	protected SplFileObject $file;
 	protected UsageList $usageList;
 
@@ -16,6 +21,24 @@ abstract class Upload {
 		$this->file = new SplFileObject($this->filePath);
 		$this->usageList = new UsageList();
 		$this->processUsages();
+
+		$this->filename = pathinfo($this->filePath, PATHINFO_FILENAME);
+		$this->size = filesize($this->filePath);
+
+		$bytes = $this->size;
+		$units = ["B", "KB", "MB", "GB", "TB", "PB"];
+		for($i = 0; $bytes > 1024; $i++) {
+			$bytes /= 1024;
+		}
+		$this->sizeString = round($bytes, 1)
+			. " "
+			. $units[$i];
+
+		$className = get_class($this);
+		$this->type = match($className) {
+			default => str_replace("Upload", "", substr($className, strrpos($className, "\\") + 1)),
+			PRSStatementUpload::class => "PRS Statement",
+		};
 	}
 
 	public function getUsageTotal():Money {

--- a/page/index.html
+++ b/page/index.html
@@ -3,25 +3,52 @@
 <meta name="viewport" content="width=device-width, initial-scale:1" />
 <title>Trackshift</title>
 <link rel="stylesheet" href="/style.css" />
+<script src="/script.js" defer></script>
 
 <h1>Trackshift</h1>
 
-<p data-template="error"></p>
+<details>
+	<summary>
+		Uploaded files (<span data-bind:text="uploadCount">0</span>)
+	</summary>
+	<ul>
+		<li data-template>
+			<form method="post">
+				<input type="hidden" name="filename" data-bind:value="filename" />
+
+				<strong data-bind:text="filename">abc.xyz</strong>
+				- <span data-bind:text="sizeString">0B</span>
+				- <span data-bind:text="type">Type</span>
+
+				<button name="do" value="delete" onclick="return confirm('Are you sure you want to remove {{filename}}?')">
+					<span>Delete <span data-bind:text="filename" hidden>filename</span></span>
+				</button>
+			</form>
+		</li>
+	</ul>
+
+	<form method="post">
+		<button name="do" value="clear" onclick="return confirm('Are you sure you want to remove all your uploaded files?')">Clear uploads</button>
+	</form>
+	<br/>
+	<br/>
+</details>
+
+<br/>
+<br/>
 
 <form method="post" enctype="multipart/form-data">
 	<label>
 		<span>Upload your statement file</span>
-		<input type="file" name="statement" required />
+		<input type="file" name="statement[]" multiple required />
 	</label>
 	<button name="do" value="upload">Upload</button>
 </form>
 
-<form method="post">
-	<button name="do" value="clear">Clear uploads</button>
-</form>
+<br/>
+<br/>
 
-
-<table>
+<table border="1" cellpadding="8">
 	<thead>
 		<tr>
 			<th>Work title</th>

--- a/script/script.es6
+++ b/script/script.es6
@@ -1,0 +1,15 @@
+const uploadInput = document.querySelector("input[type=file]");
+const uploadLabel = uploadInput.closest("label");
+
+document.body.addEventListener("dragover", e => {
+	uploadLabel.classList.add("dragging");
+	e.preventDefault();
+});
+document.body.addEventListener("dragleave", () => {
+	uploadLabel.classList.remove("dragging");
+});
+document.body.addEventListener("drop", e => {
+	uploadLabel.classList.remove("dragging");
+	e.preventDefault();
+	uploadInput.files = e.dataTransfer.files;
+});

--- a/style/style.scss
+++ b/style/style.scss
@@ -1,0 +1,8 @@
+label.dragging {
+	&::before {
+		content: "Drop your files to upload!";
+		display: block;
+		border: 4px dashed black;
+		padding: 2rem 1rem;
+	}
+}

--- a/test/behat/features/anonymous-user.feature
+++ b/test/behat/features/anonymous-user.feature
@@ -15,7 +15,7 @@ Feature: App should be usable by anonymous users
 		Given I am on the homepage
 		When I attach the file "gubbins.txt" to "statement"
 		And I press "Upload"
-		Then I should see "ERROR: Unknown file type"
+		Then I should see "Gubbins - 2.2 KB - Unknown"
 
 	Scenario: I can upload a PRS statement
 		Given I am on the homepage

--- a/test/behat/features/manage-uploads.feature
+++ b/test/behat/features/manage-uploads.feature
@@ -1,0 +1,38 @@
+Feature: App should list out and remove uploaded files
+	In order to retain control over my uploaded files
+	As an uploader
+	I should be able to manage the list of uploaded files on my account
+
+	Scenario: I can see uploads list
+		Given I am on the homepage
+		Then I should see "Uploaded files (0)"
+
+		When I attach the file "prs-simple-3-songs.csv" to "statement"
+		And I press "Upload"
+		Then I should see "Uploaded files (1)"
+		And I should see "prs-simple-3-songs - 299 B - PRS Statement"
+
+		When I attach the file "prs-simple-3-songs-another-statement.csv" to "statement"
+		And I press "Upload"
+		Then I should see "Uploaded files (2)"
+		And I should see "prs-simple-3-songs-another-statement - 273 B - PRS Statement"
+		# Existing file should still be present!
+		And I should see "prs-simple-3-songs - 299 B - PRS Statement"
+
+		When I attach the file "gubbins.txt" to "statement"
+		And I press "Upload"
+		Then I should see "Uploaded files (3)"
+		And I should see "gubbins - 2.2 KB - Unknown"
+		# Existing file should still be present!
+		And I should see "prs-simple-3-songs-another-statement - 273 B - PRS Statement"
+		And I should see "prs-simple-3-songs - 299 B - PRS Statement"
+
+	Scenario: I can delete an individual upload
+		Given I am on the homepage
+		When I attach the file "prs-simple-3-songs.csv" to "statement"
+		And I press "Upload"
+		And I attach the file "prs-simple-3-songs-another-statement.csv" to "statement"
+		And I press "Upload"
+		Then I should see "Uploaded files (2)"
+		When I press "Delete prs-simple-3-songs"
+		Then I should see "Uploaded files (1)"


### PR DESCRIPTION
In this PR:

+ HTML file input has new `multiple` attribute
+ PHP loops over the files as a collection, rather than assuming a single upload
+ List of uploads are listed to the user
+ User can remove one or all of the uploads at will
+ Drag and drop as a bonus extra