### PR TITLE
feature: store user id in the session

### DIFF
--- a/page/index.php
+++ b/page/index.php
@@ -10,7 +10,6 @@ use Trackshift\Upload\UploadManager;
 
 function go(
 	UploadManager $uploadManager,
-	Input $input,
 	Response $response,
 	HTMLDocument $document,
 	DocumentBinder $binder,
@@ -18,7 +17,8 @@ function go(
 ):void {
 	$uploadManager->purge();
 
-	if($userId = $input->getString("user")) {
+	if($userId = $session->getString("ulid")) {
+		$document->body->dataset->set("hash", substr($userId, -3));
 		$userDataDir = "data/$userId";
 
 		$statement = $uploadManager->load(...glob("$userDataDir/*.*"));
@@ -56,12 +56,12 @@ function go(
 	else {
 		$ulid = $session->getString("ulid") ?? new Ulid();
 		$session->set("ulid", $ulid);
-		$response->redirect("./?user=" . $ulid);
+		$response->reload();
 	}
 }
 
-function do_upload(Input $input, Response $response):void {
-	$userId = $input->getString("user");
+function do_upload(Session $session, Input $input, Response $response):void {
+	$userId = $session->getString("ulid");
 	if(!$userId) {
 		$response->reload();
 	}
@@ -77,11 +77,11 @@ function do_upload(Input $input, Response $response):void {
 		$file->moveTo($targetPath);
 	}
 
-	$response->redirect("./?user=$userId");
+	$response->reload();
 }
 
-function do_clear(Input $input, Response $response):void {
-	$userId = $input->getString("user");
+function do_clear(Session $session, Response $response):void {
+	$userId = $session->getString("ulid");
 	if(!$userId) {
 		$response->reload();
 	}
@@ -90,11 +90,11 @@ function do_clear(Input $input, Response $response):void {
 		unlink($file);
 	}
 
-	$response->redirect("./?user=$userId");
+	$response->reload();
 }
 
-function do_delete(Input $input, Response $response):void {
-	$userId = $input->getString("user");
+function do_delete(Session $session, Input $input, Response $response):void {
+	$userId = $session->getString("ulid");
 	if(!$userId) {
 		$response->reload();
 	}
@@ -104,11 +104,11 @@ function do_delete(Input $input, Response $response):void {
 		unlink($file);
 	}
 
-	$response->redirect("./?user=$userId");
+	$response->reload();
 }
 
-function do_extend(Input $input, Response $response):void {
-	$userId = $input->getString("user");
+function do_extend(Session $session, Response $response):void {
+	$userId = $session->getString("ulid");
 	if(!$userId) {
 		$response->reload();
 	}
@@ -119,5 +119,5 @@ function do_extend(Input $input, Response $response):void {
 		touch($dir, $dateIn3weeks->getTimestamp());
 	}
 
-	$response->redirect("./?user=$userId");
+	$response->reload();
 }

--- a/test/behat/features/bootstrap/FeatureContext.php
+++ b/test/behat/features/bootstrap/FeatureContext.php
@@ -49,11 +49,9 @@ class FeatureContext extends MinkContext {
 
 	/** @Then a new user ID should be generated */
 	public function aNewUserIDShouldBeGenerated() {
-		$url = $this->getSession()->getCurrentUrl();
-		$query = parse_url($url, PHP_URL_QUERY);
-		parse_str($query, $queryParts);
-		PHPUnit::assertArrayHasKey("user", $queryParts);
-		PHPUnit::assertGreaterThan(16, strlen($queryParts["user"]));
+		$body = $this->getSession()->getPage()->find("css", "body");
+		PHPUnit::assertTrue($body->hasAttribute("data-hash"));
+		PHPUnit::assertSame(3, strlen($body->getAttribute("data-hash")));
 	}
 
 	/** @Then I should see :numRows rows in the table */


### PR DESCRIPTION
closes #45 

When the user ID is generated, it's stored in the session rather than exposed in the URL. I did it in the URL at first for simplicity, but given how sharable URLs are, I think that was a bad call.

To test this, the last 3 digits of the user ID are added to the body's `data-hash` attribute. You should see that it stays the same for you while you're in the same browser session, and if you use a different browser or clear your cookies, you'll see the hash change.